### PR TITLE
Allow use of numpad keys

### DIFF
--- a/src/input/Keyboard.ts
+++ b/src/input/Keyboard.ts
@@ -17,13 +17,15 @@ keyToIntentMappings.set("ArrowDown", [ControllerIntent.PLAYER_DROP, ControllerIn
 keyToIntentMappings.set("ArrowLeft", [ControllerIntent.PLAYER_MOVE_LEFT, ControllerIntent.MENU_LEFT]);
 keyToIntentMappings.set("ArrowRight", [ControllerIntent.PLAYER_MOVE_RIGHT, ControllerIntent.MENU_RIGHT]);
 keyToIntentMappings.set("Enter", [ControllerIntent.PLAYER_INTERACT, ControllerIntent.CONFIRM]);
+keyToIntentMappings.set("NumpadEnter", [ControllerIntent.PLAYER_INTERACT, ControllerIntent.CONFIRM]);
 keyToIntentMappings.set("Escape", [ControllerIntent.ABORT, ControllerIntent.PAUSE]);
 keyToIntentMappings.set("ShiftLeft", [ControllerIntent.PLAYER_RUN]);
 keyToIntentMappings.set("ShiftRight", [ControllerIntent.PLAYER_RUN]);
 keyToIntentMappings.set("KeyE", [ControllerIntent.PLAYER_INTERACT, ControllerIntent.CONFIRM]);
 keyToIntentMappings.set("KeyF", [ControllerIntent.PLAYER_ACTION]);
 keyToIntentMappings.set("Digit1", [ControllerIntent.PLAYER_DANCE_1]);
-keyToIntentMappings.set("Digit2", [ControllerIntent.PLAYER_DANCE_2]);
+keyToIntentMappings.set("Numpad1", [ControllerIntent.PLAYER_DANCE_1]);
+keyToIntentMappings.set("Numpad2", [ControllerIntent.PLAYER_DANCE_2]);
 
 export class Keyboard {
     public readonly onKeyDown = new Signal<KeyboardEvent>();

--- a/src/input/Keyboard.ts
+++ b/src/input/Keyboard.ts
@@ -24,6 +24,7 @@ keyToIntentMappings.set("ShiftRight", [ControllerIntent.PLAYER_RUN]);
 keyToIntentMappings.set("KeyE", [ControllerIntent.PLAYER_INTERACT, ControllerIntent.CONFIRM]);
 keyToIntentMappings.set("KeyF", [ControllerIntent.PLAYER_ACTION]);
 keyToIntentMappings.set("Digit1", [ControllerIntent.PLAYER_DANCE_1]);
+keyToIntentMappings.set("Digit2", [ControllerIntent.PLAYER_DANCE_2]);
 keyToIntentMappings.set("Numpad1", [ControllerIntent.PLAYER_DANCE_1]);
 keyToIntentMappings.set("Numpad2", [ControllerIntent.PLAYER_DANCE_2]);
 


### PR DESCRIPTION
Keys for confirming (`↲`) and dancing (`1`, `2`) are also present on numpad and should be available for use in the game. They might be a little more accessible for some users and it generally avoids confusion when they just work as expected.