### PR TITLE
Use navigator.keyboard.lock().

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <link rel="manifest" href="manifest.webmanifest" />
   </head>
   <body>
+    <div id="background"></div>
     <script src="node_modules/steal/steal.js" main="lib/FriendlyFire"></script>
   </body>
 </html>

--- a/src/FriendlyFire.ts
+++ b/src/FriendlyFire.ts
@@ -7,15 +7,7 @@ export class FriendlyFire extends Game {
     }
 }
 
-(async () => {
-
-    if ("keyboard" in navigator && "lock" in navigator.keyboard && typeof navigator.keyboard.lock === "function") {
-        await navigator.keyboard.lock();
-    }
-
-    const game = new FriendlyFire();
-    game.scenes.setScene(LoadingScene);
-    (window as any).game = game;
-    game.start();
-
-})();
+const game = new FriendlyFire();
+game.scenes.setScene(LoadingScene);
+(window as any).game = game;
+game.start();

--- a/src/FriendlyFire.ts
+++ b/src/FriendlyFire.ts
@@ -7,7 +7,15 @@ export class FriendlyFire extends Game {
     }
 }
 
-const game = new FriendlyFire();
-game.scenes.setScene(LoadingScene);
-(window as any).game = game;
-game.start();
+(async () => {
+
+    if ("keyboard" in navigator && "lock" in navigator.keyboard && typeof navigator.keyboard.lock === "function") {
+        await navigator.keyboard.lock();
+    }
+
+    const game = new FriendlyFire();
+    game.scenes.setScene(LoadingScene);
+    (window as any).game = game;
+    game.start();
+
+})();

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -55,8 +55,14 @@ export abstract class Game {
         window.addEventListener("keydown", async (event) => {
             if (event.altKey && event.key === "Enter") {
                 if (document.fullscreenElement === null) {
+                    if ("keyboard" in navigator && "lock" in navigator.keyboard && typeof navigator.keyboard.lock === "function") {
+                        await navigator.keyboard.lock(["Escape"]);
+                    }
                     await this.canvas.requestFullscreen();
                 } else {
+                    if ("keyboard" in navigator && "lock" in navigator.keyboard && typeof navigator.keyboard.lock === "function") {
+                        navigator.keyboard.unlock();
+                    }
                     await document.exitFullscreen();
                 }
             }

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -54,13 +54,14 @@ export abstract class Game {
         // Use Alt+Enter to toggle fullscreen mode.
         window.addEventListener("keydown", async (event) => {
             if (event.altKey && event.key === "Enter") {
+                const lockingEnabled = "keyboard" in navigator && "lock" in navigator.keyboard && typeof navigator.keyboard.lock === "function";
                 if (document.fullscreenElement === null) {
-                    if ("keyboard" in navigator && "lock" in navigator.keyboard && typeof navigator.keyboard.lock === "function") {
+                    if (lockingEnabled) {
                         await navigator.keyboard.lock(["Escape"]);
                     }
                     await this.canvas.requestFullscreen();
                 } else {
-                    if ("keyboard" in navigator && "lock" in navigator.keyboard && typeof navigator.keyboard.lock === "function") {
+                    if (lockingEnabled) {
                         navigator.keyboard.unlock();
                     }
                     await document.exitFullscreen();

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -59,7 +59,7 @@ export abstract class Game {
                     if (lockingEnabled) {
                         await navigator.keyboard.lock(["Escape"]);
                     }
-                    await this.canvas.requestFullscreen();
+                    await document.body.requestFullscreen();
                 } else {
                     if (lockingEnabled) {
                         navigator.keyboard.unlock();

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -55,16 +55,17 @@ export abstract class Game {
         window.addEventListener("keydown", async (event) => {
             if (event.altKey && event.key === "Enter") {
                 const lockingEnabled = "keyboard" in navigator && "lock" in navigator.keyboard && typeof navigator.keyboard.lock === "function";
-                if (document.fullscreenElement === null) {
-                    if (lockingEnabled) {
-                        await navigator.keyboard.lock(["Escape"]);
-                    }
-                    await document.body.requestFullscreen();
-                } else {
+                // If the browser is in full screen mode AND fullscreen has been triggered by our own keyboard shortcut...
+                if (window.matchMedia("(display-mode: fullscreen)").matches && document.fullscreenElement != null) {
                     if (lockingEnabled) {
                         navigator.keyboard.unlock();
                     }
                     await document.exitFullscreen();
+                } else {
+                    if (lockingEnabled) {
+                        await navigator.keyboard.lock(["Escape"]);
+                    }
+                    await document.body.requestFullscreen();
                 }
             }
         });

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -50,6 +50,18 @@ export abstract class Game {
         this.updateCanvasSize();
         window.addEventListener("resize", () => this.updateCanvasSize());
         window.addEventListener("pointermove", () => this.mouseMoved());
+
+        // Use Alt+Enter to toggle fullscreen mode.
+        window.addEventListener("keydown", async (event) => {
+            if (event.altKey && event.key === "Enter") {
+                if (document.fullscreenElement === null) {
+                    await this.canvas.requestFullscreen();
+                } else {
+                    await document.exitFullscreen();
+                }
+            }
+        });
+
     }
 
     private mouseMoved(): void {

--- a/src/input/Keyboard.ts
+++ b/src/input/Keyboard.ts
@@ -48,6 +48,14 @@ export class Keyboard {
     private handleKeyPress(event: KeyboardEvent): void {
         this.onKeyPress.emit(event);
 
+        // Quick workaround to make sure, that modifier keys never trigger a game-related
+        // controller event. Especially necessary to make other non-game related actions
+        // possible. (Shift is used as a modifier key to enable running and is therefore
+        // excluded from the list below)
+        if (event.altKey || event.ctrlKey || event.metaKey) {
+            return;
+        }
+
         this.controllerManager.onButtonPress.emit(
             new ControllerEvent(
                 ControllerFamily.KEYBOARD, ControllerEventType.PRESS,
@@ -67,6 +75,10 @@ export class Keyboard {
 
         this.onKeyDown.emit(event);
 
+        if (event.altKey || event.ctrlKey || event.metaKey) {
+            return;
+        }
+
         this.controllerManager.onButtonDown.emit(
             new ControllerEvent(
                 ControllerFamily.KEYBOARD, ControllerEventType.DOWN,
@@ -81,6 +93,10 @@ export class Keyboard {
         }
 
         this.onKeyUp.emit(event);
+
+        if (event.altKey || event.ctrlKey || event.metaKey) {
+            return;
+        }
 
         this.controllerManager.onButtonUp.emit(
             new ControllerEvent(

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -1,0 +1,14 @@
+export {}
+
+
+interface Keyboard {
+    async lock(keyCodes?: Iterable<DOMString>): Promise<void>;
+    unlock(): void;
+}
+
+declare global {
+    interface Navigator {
+        // See https://wicg.github.io/keyboard-lock/
+        readonly keyboard: Keyboard
+    }
+}

--- a/style.css
+++ b/style.css
@@ -1,12 +1,15 @@
-html {
+html, body {
     padding: 0;
     margin: 0;
 }
 
-body {
+#background {
     background-color: #202020;
-    padding: 0;
-    margin: 0;
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
 }
 
 #gameCanvas {


### PR DESCRIPTION
Also: add support for switching to/from fullscreen with Alt+Enter.
For now, this requires an ugly workaround where modifier keys
(especially "alt") have to be captured to prevent game-related
"Controller" events.

I suppose the whole event-based controller logic shows more and
more limitations...